### PR TITLE
Use pipeline image processor

### DIFF
--- a/daam/trace.py
+++ b/daam/trace.py
@@ -137,8 +137,11 @@ class PipelineHooker(ObjectHooker[StableDiffusionPipeline]):
 
     def _hooked_run_safety_checker(hk_self, self: StableDiffusionPipeline, image, *args, **kwargs):
         image, has_nsfw = hk_self.monkey_super('run_safety_checker', image, *args, **kwargs)
-        pil_image = self.numpy_to_pil(image)
-        hk_self.parent_trace.last_image = pil_image[0]
+        if torch.is_tensor(image):
+            images = self.image_processor.postprocess(image, output_type="pil")
+        else:
+            images = self.image_processor.numpy_to_pil(image)
+        hk_self.parent_trace.last_image = images[len(images)-1] 
 
         return image, has_nsfw
 

--- a/daam/trace.py
+++ b/daam/trace.py
@@ -137,10 +137,15 @@ class PipelineHooker(ObjectHooker[StableDiffusionPipeline]):
 
     def _hooked_run_safety_checker(hk_self, self: StableDiffusionPipeline, image, *args, **kwargs):
         image, has_nsfw = hk_self.monkey_super('run_safety_checker', image, *args, **kwargs)
-        if torch.is_tensor(image):
-            images = self.image_processor.postprocess(image, output_type="pil")
+
+        if "image_processor" in self:
+            if torch.is_tensor(image):
+                images = self.image_processor.postprocess(image, output_type="pil")
+            else:
+                images = self.image_processor.numpy_to_pil(image)
         else:
-            images = self.image_processor.numpy_to_pil(image)
+            images = self.numpy_to_pil(image)
+
         hk_self.parent_trace.last_image = images[len(images)-1] 
 
         return image, has_nsfw

--- a/daam/trace.py
+++ b/daam/trace.py
@@ -138,7 +138,7 @@ class PipelineHooker(ObjectHooker[StableDiffusionPipeline]):
     def _hooked_run_safety_checker(hk_self, self: StableDiffusionPipeline, image, *args, **kwargs):
         image, has_nsfw = hk_self.monkey_super('run_safety_checker', image, *args, **kwargs)
 
-        if "image_processor" in self:
+        if self.image_processor:
             if torch.is_tensor(image):
                 images = self.image_processor.postprocess(image, output_type="pil")
             else:


### PR DESCRIPTION
This updates the image processing to use the image_processor of the pipeline. Was needed to support newer version of diffusers. 

Listed version tested on.

```
diffusers                 0.21.2
transformers              4.30.2
accelerate                0.23.0
```

I didn't do a full test of all features. 

Fixes #54 