### PR TITLE
Add support for InstructPix2Pix Fixes #40

### DIFF
--- a/daam/trace.py
+++ b/daam/trace.py
@@ -237,7 +237,12 @@ class UNetCrossAttentionHooker(ObjectHooker[Attention]):
         with auto_autocast(dtype=torch.float32):
             for map_ in x:
                 map_ = map_.view(map_.size(0), h, w)
-                map_ = map_[map_.size(0) // 2:]  # Filter out unconditional
+                # For Instruct Pix2Pix, divide the map into three parts: text condition, image condition and unconditional,
+                # and only keep the text condition part, which is first of the three parts(as per diffusers implementation).
+                if map_.size(0) == 24:
+                    map_ = map_[:((map_.size(0) // 3)+1)]  # Filter out unconditional and image condition
+                else:
+                    map_ = map_[map_.size(0) // 2:] #  # Filter out unconditional
                 maps.append(map_)
 
         maps = torch.stack(maps, 0)  # shape: (tokens, heads, height, width)


### PR DESCRIPTION
The original DAAM divides the attention maps into 2 chunks, one corresponding to text conditions and the other unconditional. It then uses text conditioning to calculate cross-attention maps.

InstructPix2Pix has 3 chunks, one corresponding to text conditions, one for image conditions and the other for unconditional. 

The modified DAAM checks if the size of `map_` is 24 instead of the original 16. If true, it divides the maps into 3 chunks instead of 2 allowing the attention maps to be generated correctly.

![Meeting Whiteboard (1)](https://github.com/castorini/daam/assets/77379835/eeba0c39-1e28-4bf9-b2dd-7682f48b447b)

Old attention maps(All maps have the same output:
![old](https://github.com/castorini/daam/assets/77379835/a6312b26-6ad4-4760-9113-20fe386554ce)

New attention maps:
|Image1|Image2|Image3|
| ----------- |-----------|-------------|
|![image (6)](https://github.com/castorini/daam/assets/77379835/5e6ec586-90de-4e29-9149-26e8838250ab)|![image (7)](https://github.com/castorini/daam/assets/77379835/c77e04d3-ff5e-4a0f-b21c-30906b5cb4e5)|![image (8)](https://github.com/castorini/daam/assets/77379835/28c18f31-eab9-43d3-831d-a17b1e4871f6)|

